### PR TITLE
Modified lambdas to get the bucket as env var

### DIFF
--- a/lambdas/DeleteSnippetFromS3/index.js
+++ b/lambdas/DeleteSnippetFromS3/index.js
@@ -19,15 +19,6 @@ const sendResponse = (callback, statusCode, response) => {
   })
 }
 
-// Given an apiID, returns the corresponding S3 bucket; or null if none exists
-const mapApiIdToBucket = (apiID) => {
-  // TODO: Add Other environments to process.env and if statement
-  switch(apiID) {
-    case process.env.devID: return process.env.devBucket;
-    default: return null;
-  }
-}
-
 // Deletes the object with the given Key from the given Bucket. Returns a Promise.
 const deleteFromS3 = (Bucket, Key) => {
   const params = {
@@ -75,16 +66,8 @@ exports.handler = (event, context, callback) => {
     const snippetID = event.pathParameters.snippet_id;
     const key       = `${userID}/${snippetID}`;
     const apiID     = event.requestContext.apiId;
-    const bucket    = mapApiIdToBucket(apiID);
+    const bucket    = process.env.BucketName;
 
-    // Respond with a 400 is the apiID wasn't mapped to an S3 bucket
-    if (bucket === null) {
-      const msg = `Unrecognized apiId: ${apiID}`;
-      console.error(msg);
-      sendResponse(callback, '400', msg);
-    }
-
-    // apiID mapped to an S3 bucket, so delete from there
     deleteFromS3(bucket, key)
       .then(() => {
         sendResponse(callback, '200', 'Successfully deleted.');

--- a/lambdas/GetSnippetFromS3/index.js
+++ b/lambdas/GetSnippetFromS3/index.js
@@ -9,14 +9,7 @@ const s3 = new aws.S3({ apiVersion: '2006-03-01' });
 
 exports.handler = (event, context, callback) => {
     const key = event.pathParameters.user_id + "/" + event.pathParameters.snippet_id;
-    let bucket;
-
-    // TODO: Add Other environments to process.env and if statement
-    if (event.requestContext.apiId === process.env.devID) {
-        bucket = process.env.devBucket;
-    } else {
-        console.err("Invalid apiId" + event.requestContext.apiId);
-    }
+    const bucket = process.env.BucketName;
 
     const params = {
         Bucket: bucket,
@@ -26,7 +19,7 @@ exports.handler = (event, context, callback) => {
         if (err) {
             const message = `Error getting object ${params.Key} from bucket ${bucket}`;
             callback(message);
-            context.fail({ 
+            context.fail({
                 statusCode: 400,
                 headers: {
                     'Access-Control-Allow-Origin': '*',
@@ -35,7 +28,7 @@ exports.handler = (event, context, callback) => {
 
         } else {
             const object = data.Body.toString();
-            context.succeed({ 
+            context.succeed({
                 statusCode: 200,
                 headers: {
                     'Access-Control-Allow-Origin': '*',

--- a/lambdas/SaveSnippetToS3/index.js
+++ b/lambdas/SaveSnippetToS3/index.js
@@ -19,15 +19,6 @@ const sendResponse = (callback, statusCode, response) => {
   })
 }
 
-// Given an apiID, returns the corresponding S3 bucket; or null if none exists
-const mapApiIdToBucket = (apiID) => {
-  // TODO: Add Other environments to process.env and if statement
-  switch(apiID) {
-    case process.env.devID: return process.env.devBucket;
-    default: return null;
-  }
-}
-
 // Saves the given Body to the given Bucket under the given Key. Returns a Promise.
 const saveToS3 = (Bucket, Key, Body) => {
   const params = {
@@ -77,16 +68,8 @@ exports.handler = (event, context, callback) => {
     const snippetKey = body.snippetTitle.replace(/\s+/g, '_').toLowerCase();
     const key        = `${userID}/${snippetKey}`;
     const apiID      = event.requestContext.apiId;
-    const bucket     = mapApiIdToBucket(apiID);
+    const bucket     = process.env.BucketName;
 
-    // Respond with a 400 if the apiID wasn't mapped to an S3 bucket
-    if (bucket === null) {
-      const msg = `Unrecognized apiId: ${apiID}`;
-      console.err(msg);
-      sendResponse(callback, '400', msg);
-    }
-
-    // apiID mapped to an S3 bucket, so save to that
     saveToS3(bucket, key, event.body)
       .then(key => {
         callback(null, {

--- a/lambdas/UpdateSnippetInS3/index.js
+++ b/lambdas/UpdateSnippetInS3/index.js
@@ -19,15 +19,6 @@ const sendResponse = (callback, statusCode, response) => {
   })
 }
 
-// Given an apiID, returns the corresponding S3 bucket; or null if none exists
-const mapApiIdToBucket = (apiID) => {
-  // TODO: Add Other environments to process.env and if statement
-  switch(apiID) {
-    case process.env.devID: return process.env.devBucket;
-    default: return null;
-  }
-}
-
 // Saves the given Body to the given Bucket under the given Key. Returns a Promise.
 const saveToS3 = (Bucket, Key, Body) => {
   const params = {
@@ -76,16 +67,8 @@ exports.handler = (event, context, callback) => {
     const snippetID = event.pathParameters.snippet_id;
     const key       = `${userID}/${snippetID}`;
     const apiID     = event.requestContext.apiId;
-    const bucket    = mapApiIdToBucket(apiID);
+    const bucket    = process.env.BucketName;
 
-    // Respond with a 400 if the apiID wasn't mapped to an S3 bucket
-    if (bucket === null) {
-      const msg = `Unrecognized apiId: ${apiID}`;
-      console.err(msg);
-      sendResponse(callback, '400', msg);
-    }
-
-    // apiID mapped to an S3 bucket, so save to that
     saveToS3(bucket, key, event.body)
       .then(key => {
         callback(null, {


### PR DESCRIPTION
Fixes #7.

Lambdas no longer make a comparison of the `apiID` to the `devID`, etc, to determine what bucket to save to. The bucket is now explicitly given to them with the `BucketName` environment variable.