### PR TITLE
Refactor SaveSnippetToS3 to call encodeURIComponent on snippet titles

### DIFF
--- a/lambdas/SaveSnippetToS3/index.js
+++ b/lambdas/SaveSnippetToS3/index.js
@@ -66,7 +66,7 @@ exports.handler = (event, context, callback) => {
 
     /* ----- Otherwise, save to S3 ----- */
     const body       = JSON.parse(event.body);
-    const snippetKey = body.snippetTitle.replace(/\s+/g, '_').toLowerCase();
+    const snippetKey = encodeURIComponent(body.snippetTitle.replace(/\s+/g, '_').toLowerCase());
     const key        = `${userID}/${snippetKey}`;
     const apiID      = event.requestContext.apiId;
     const bucket     = process.env.BucketName;


### PR DESCRIPTION
Fixes #21

This PR will URI encode the snippet title (after prior substitutions have been applied). Documentation for the function used can be found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)