### PR TITLE
used correct url quoting function

### DIFF
--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -12,7 +12,7 @@ client = boto3.client('lambda')
 
 # Returns the snippet key with the lowest possible unused postfix value.
 def generate_snippet_id(bucket, user_id, snippet_title):
-    snippet_id = urllib.quote(string.lower(re.sub(r'\s+', '_', snippet_title)))
+    snippet_id = urllib.quote_plus(string.lower(re.sub(r'\s+', '_', snippet_title)))
     if object_exists(bucket, user_id, snippet_id):
         return generate_snippet_id(bucket, user_id, next_title(snippet_title))
     return snippet_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
used `quote_plus` instead of `quote` 

Before: `https://google.com?q=somestuff => https%3A//google.com%3Fq%3Dsomestuff`
After: `https://google.com?q=somestuff => https%3A%2F%2Fgoogle.com%3Fq%3Dsomestuff`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #60

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] All new and existing tests passed.
