### PR TITLE
Release parser

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
   environment:
     # Which version of the parser you want to deploy into qa/prod
     RELEASED_PARSER: v0.4
-    TEST: test
 
 dependencies:
   override:
@@ -91,7 +90,6 @@ deployment:
   feature:
     branch: /^((?!master).)*$/ # not master
     commands:
-      - echo "$TEST"
       # Zip and push lambda code to S3 bucket under sandbox/branch
       - bash publish codesplain-lambda-functions/sandbox/$CIRCLE_BRANCH
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,9 @@
 machine:
   node:
     version: 7.7.2
+  environment:
+    # Which version of the parser you want to deploy into qa/prod
+    RELEASED_PARSER: v0.4
 
 dependencies:
   override:
@@ -38,6 +41,7 @@ deployment:
         ClientID="$CLIENT_ID_PROD"
         Title="CodesplainAPI: $CIRCLE_TAG"
         CircleBuild="$CIRCLE_BUILD_NUM"
+        ParserPath="$RELEASED_PARSER"
         --region us-west-2
 
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
   environment:
     # Which version of the parser you want to deploy into qa/prod
     RELEASED_PARSER: v0.4
+    TEST: test
 
 dependencies:
   override:
@@ -90,6 +91,7 @@ deployment:
   feature:
     branch: /^((?!master).)*$/ # not master
     commands:
+      - echo "$TEST"
       # Zip and push lambda code to S3 bucket under sandbox/branch
       - bash publish codesplain-lambda-functions/sandbox/$CIRCLE_BRANCH
 

--- a/circle.yml
+++ b/circle.yml
@@ -111,4 +111,5 @@ deployment:
         ClientID="$AuthId"
         Title="Codesplain Feature:$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"
         CircleBuild="$CIRCLE_BUILD_NUM"
+        ParserPath="$RELEASED_PARSER"
         --region us-west-2

--- a/circle.yml
+++ b/circle.yml
@@ -111,5 +111,4 @@ deployment:
         ClientID="$AuthId"
         Title="Codesplain Feature:$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"
         CircleBuild="$CIRCLE_BUILD_NUM"
-        ParserPath="$RELEASED_PARSER"
         --region us-west-2


### PR DESCRIPTION
Tested temporarily with my feature branch stack

## Description
This was missing from the tag/release builds, so they would always be pulling parsers from the default `dev` path.

## Motivation and Context
Closes #81 