### PR TITLE
add sha to s3 path for feature branches

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -87,7 +87,7 @@ deployment:
     branch: /^((?!master).)*$/ # not master
     commands:
       # Zip and push lambda code to S3 bucket under sandbox/branch
-      - bash publish codesplain-lambda-functions/sandbox/$CIRCLE_BRANCH
+      - bash publish codesplain-lambda-functions/sandbox/$CIRCLE_BRANCH/$CIRCLE_SHA1
 
       # Package template for deploying to feature branch API
       - >
@@ -102,7 +102,7 @@ deployment:
         --template-file ./serverless-output-sandbox.yaml
         --parameter-overrides
         EnvVersion="$CIRCLE_BRANCH"
-        S3Version="sandbox/$CIRCLE_BRANCH"
+        S3Version="sandbox/$CIRCLE_BRANCH/$CIRCLE_SHA1"
         ClientSecret="$AuthSecret"
         ClientID="$AuthId"
         Title="Codesplain Feature:$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"


### PR DESCRIPTION
## Description
This will cause feature branches to refresh the lambda code on each push, which was a regression when I switched to update over delete and redeploy.

## Motivation and Context
Closes #84 

Confirmed in S3