### PR TITLE
Remove auth on snippet GETs

### DIFF
--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -464,8 +464,6 @@ Resources:
                     $ref: "#/definitions/Snippet"
                 "404":
                   description: "404 response"
-              security:
-              - GithubAuthorizer: []
               x-amazon-apigateway-integration:
                 credentials: !Ref Role
                 responses:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the GithubAuthorizer authentication from GETS to the `/users/{{user_id}}/snippets/{{snippet_id}}` endpoint. The result is that all snippets are publicly accessible (though we still have the option of adding private snippets in the future).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #32. This allows embedded Codesplain instances to retrieve snippets without dealing with authentication.
Links maryvilledev/codesplain-embedded#4

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
