### PR TITLE
Add GET method to /users endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-lambdas := Authorize AuthorizeToken DeleteSnippetFromS3 GetSnippetFromS3 SaveSnippetToS3 GenerateIndexFiles GitHubAccessCodeGetter UpdateSnippetInS3
+lambdas := Authorize AuthorizeToken DeleteSnippetFromS3 GetSnippetFromS3 GetIndexes SaveSnippetToS3 GenerateIndexFiles GitHubAccessCodeGetter UpdateSnippetInS3
 zipdir := zips
 lambdadir := lambdas
 .PHONY = all clean publish $(lambdas)

--- a/api_tests/run-tests
+++ b/api_tests/run-tests
@@ -12,5 +12,6 @@ function run {
 run auth.test_endpoint.TestEndpoint.run_tests && \
 run parsers.test_endpoint.TestEndpoint.run_tests && \
 run mappings.test_endpoint.TestEndpoint.run_tests && \
+run users.test_endpoint.TestEndpoint.run_tests && \
 run users.user_id.snippets.test_endpoint.TestEndpoint.run_tests && \
 run users.user_id.snippets.snippet_id.test_endpoint.TestEndpoint.run_tests

--- a/api_tests/users/test_endpoint.py
+++ b/api_tests/users/test_endpoint.py
@@ -1,0 +1,86 @@
+import unittest
+import json
+import requests
+from jsonschema import validate, ValidationError
+import config
+import testfor
+
+class TestEndpoint(unittest.TestCase):
+
+    @classmethod
+    def setUpClass (cls):
+        config_dict      = config.parse()
+        cls.USER_ID      = config_dict['user_id']
+        cls.SNIPPET_ID   = config_dict['snippet_id']
+        cls.API_URL      = config_dict['url'] + '/users'
+        cls.ACCESS_TOKEN = config_dict['access_token']
+        cls.SNIPPET      = json.dumps(config_dict['snippet'])
+
+    def run_tests (self):
+        print '\nTesting /users Endpoint:'
+        self.test_options()
+        self.test_get_no_query()
+        self.test_get_with_query()
+
+    def test_options (self):
+        print('\tTesting OPTIONS method')
+        r = requests.options(self.API_URL)
+
+        testfor.status_code(self, r, 200)
+        testfor.cors_headers(self, r, {
+            'Headers' : 'Content-Type,X-Amz-Date,Authorization,x-api-key,x-amz-security-token',
+            'Methods' : 'GET,OPTIONS',
+            'Origin'  : '*'
+        })
+        testfor.body(self, r, '')
+
+    def test_get_no_query (self):
+        print '\tTesting GET method (with no query string)'
+        r = requests.get(self.API_URL)
+
+        testfor.status_code(self, r, 200)
+        testfor.valid_json(self, r)
+
+        print '\t\tBody object keys should be valid index entries'
+        schema = {
+            'title'      : 'Index Entry',
+            'type'       : 'object',
+            'properties' : {
+                'lastEdited'   : {'type' : 'string'},
+                'language'     : {'type' : 'string'},
+                'snippetTitle' : {'type' : 'string'},
+            },
+            'required': ['lastEdited', 'language', 'snippetTitle'],
+        }
+        for user, index in r.json().items():
+            for snippet, entry in index.items():
+                try:
+                    validate(entry, schema)
+                except ValidationError as error:
+                    self.fail('Found invalid index entry')
+
+    def test_get_with_query (self):
+        print '\tTesting GET method (with query string)'
+        url = self.API_URL + "?users=" + self.USER_ID
+        r = requests.get(url)
+
+        testfor.status_code(self, r, 200)
+        testfor.valid_json(self, r)
+
+        print '\t\tBody object keys should be valid index entries'
+        schema = {
+            'title'      : 'Index Entry',
+            'type'       : 'object',
+            'properties' : {
+                'lastEdited'   : {'type' : 'string'},
+                'language'     : {'type' : 'string'},
+                'snippetTitle' : {'type' : 'string'},
+            },
+            'required': ['lastEdited', 'language', 'snippetTitle'],
+        }
+        index = r.json()[self.USER_ID].items()
+        for snippet, entry in index:
+            try:
+                validate(entry, schema)
+            except ValidationError as error:
+                self.fail('Found invalid index entry')

--- a/api_tests/users/user_id/snippets/snippet_id/test_endpoint.py
+++ b/api_tests/users/user_id/snippets/snippet_id/test_endpoint.py
@@ -9,7 +9,7 @@ class TestEndpoint(unittest.TestCase):
 
     @classmethod
     def setUpClass (cls):
-        config_dict       = config.parse()
+        config_dict      = config.parse()
         cls.USER_ID      = config_dict['user_id']
         cls.SNIPPET_ID   = config_dict['snippet_id']
         cls.API_URL      = config_dict['url'] + '/users/' + cls.USER_ID + '/snippets/' + cls.SNIPPET_ID

--- a/api_tests/users/user_id/snippets/test_endpoint.py
+++ b/api_tests/users/user_id/snippets/test_endpoint.py
@@ -59,7 +59,7 @@ class TestEndpoint(unittest.TestCase):
             try:
                 validate(value, schema)
             except ValidationError as error:
-                self.fail("Body object keys not valid snippet meta data")
+                self.fail('Body object keys not valid snippet meta data')
                 print error
 
     def test_post (self):

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -112,6 +112,27 @@ Resources:
         Variables:
           BucketName: !Ref Bucket
 
+  GetIndexes:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: !Sub
+       - GetIndexes-${lambda_version}
+       - { lambda_version: !Ref EnvVersion }
+      Handler: lambda_function.lambda_handler
+      Runtime: python2.7
+      CodeUri:
+        Bucket: codesplain-lambda-functions
+        Key:  !Sub
+         - ${lambda_version}/GetIndexes.zip
+         - { lambda_version: !Ref S3Version }
+      Description: Returns JSON object of user/org index files
+      MemorySize: 192
+      Timeout: 3
+      Role: !Ref Role
+      Environment:
+        Variables:
+          BucketName: !Ref Bucket
+
   PutSnippet:
     Type: 'AWS::Serverless::Function'
     Properties:
@@ -341,6 +362,57 @@ Resources:
                     statusCode: "200"
                     responseParameters:
                       method.response.header.Access-Control-Allow-Methods: "'GET'"
+                      method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,x-api-key,x-amz-security-token'"
+                      method.response.header.Access-Control-Allow-Origin: "'*'"
+                requestTemplates:
+                  application/json: "{\"statusCode\": 200}"
+                passthroughBehavior: "when_no_match"
+                type: "mock"
+          "/users":
+            get:
+              produces:
+                - "application/json"
+              responses:
+                "200":
+                  description: "200 response"
+                  headers:
+                    Access-Control-Allow-Origin:
+                      type: "string"
+              x-amazon-apigateway-integration:
+                credentials: !Ref Role
+                responses:
+                  default:
+                    statusCode: "200"
+                    responseParameters:
+                      method.response.header.Access-Control-Allow-Origin: "'*'"
+                uri: !Sub
+                  - "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:296636357169:function:GetIndexes-${version}/invocations"
+                  - { version: !Ref EnvVersion}
+                passthroughBehavior: "when_no_match"
+                httpMethod: "GET"
+                contentHandling: "CONVERT_TO_TEXT"
+                type: "aws_proxy"
+            options:
+              consumes:
+              - "application/json"
+              produces:
+              - "application/json"
+              responses:
+                "200":
+                  description: "200 response"
+                  headers:
+                    Access-Control-Allow-Origin:
+                      type: "string"
+                    Access-Control-Allow-Methods:
+                      type: "string"
+                    Access-Control-Allow-Headers:
+                      type: "string"
+              x-amazon-apigateway-integration:
+                responses:
+                  default:
+                    statusCode: "200"
+                    responseParameters:
+                      method.response.header.Access-Control-Allow-Methods: "'GET, POST'"
                       method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,x-api-key,x-amz-security-token'"
                       method.response.header.Access-Control-Allow-Origin: "'*'"
                 requestTemplates:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -389,7 +389,7 @@ Resources:
                   - "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:296636357169:function:GetIndexes-${version}/invocations"
                   - { version: !Ref EnvVersion}
                 passthroughBehavior: "when_no_match"
-                httpMethod: "GET"
+                httpMethod: "POST"
                 contentHandling: "CONVERT_TO_TEXT"
                 type: "aws_proxy"
             options:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -412,7 +412,7 @@ Resources:
                   default:
                     statusCode: "200"
                     responseParameters:
-                      method.response.header.Access-Control-Allow-Methods: "'GET, POST'"
+                      method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
                       method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,x-api-key,x-amz-security-token'"
                       method.response.header.Access-Control-Allow-Origin: "'*'"
                 requestTemplates:

--- a/lambdas/GetIndexes/lambda_function.py
+++ b/lambdas/GetIndexes/lambda_function.py
@@ -1,0 +1,14 @@
+import boto3
+from boto3.s3.transfer import ClientError
+import os
+import json
+
+s3 = boto3.client('s3', 'us-west-2')
+client = boto3.client('lambda')
+
+def lambda_handler(event, context):
+    print 'running GetIndexes lambda'
+    return {
+        'statusCode': '200',
+        'headers': {'Access-Control-Allow-Origin': '*'},
+    }

--- a/lambdas/GetIndexes/lambda_function.py
+++ b/lambdas/GetIndexes/lambda_function.py
@@ -3,12 +3,76 @@ from boto3.s3.transfer import ClientError
 import os
 import json
 
+print 'running GetIndexes lambda'
+
 s3 = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
 
+# Gets the environment variable with the given name. If it
+# is not defined, then an error is raised.
+def get_env_var(name):
+    var = os.environ['BucketName']
+    if var == None:
+        print 'Must specify "%s" env var!' % name
+        raise error
+    return var
+
+# Returns all users in the given bucket, where a user is the
+# substring of an object's key from index 0 to the first '/' char.
+def get_all_users(bucket):
+    objects = s3.list_objects(Bucket=bucket)['Contents']
+    users = set()
+    for obj in objects:
+        users.add(obj['Key'].split('/')[0])
+    return users
+
+# Parses the given event object for the "users" query param.
+# Returns its value parsed as a list. If the param does not
+# exist, returns all users in the given bucket.
+def get_users(bucket, event):
+    query_params = event['queryStringParameters']
+    if query_params != None and 'users' in query_params:
+        users = query_params['users'].split(',')
+    else:
+        users = get_all_users(bucket)
+    return users
+
+# Returns true if the given user exists in the given bucket,
+# false if not
+def user_exists(bucket, user):
+    key = user + '/index.json'
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+    except ClientError as error:
+        return False
+    return True
+
+# Gets the index file for the given user within the given
+# bucket, parses it, and adds it to the given dict. If the
+# user has no index file (does not exist), an empty object
+# will be used.
+def add_user_index(dict, bucket, user):
+    if user_exists(bucket, user):
+        key = user + '/index.json'
+        index = s3.get_object(Bucket=bucket, Key=key)['Body'].read()
+        dict[user] = json.loads(index)
+    else:
+        dict[user] = '{}'
+
+# Returns a JSON object where each entry's key is a user, and its value
+# is that user's index.json. The "users" query param is used to filter
+# on users, e.g. "?users=foo,bar,qux,baz". If the "users" param is not
+# present, the returned JSON will contain all the users.
 def lambda_handler(event, context):
-    print 'running GetIndexes lambda'
+    bucket = get_env_var('BucketName')
+    users  = get_users(bucket, event)
+
+    return_dict = {}
+    for user in users:
+        add_user_index(return_dict, bucket, user)
+
     return {
         'statusCode': '200',
-        'headers': {'Access-Control-Allow-Origin': '*'},
+        'headers': { 'Access-Control-Allow-Origin': '*' },
+        'body': json.dumps(return_dict),
     }

--- a/postman.json
+++ b/postman.json
@@ -117,6 +117,23 @@
 			]
 		},
 		{
+			"name": "/users",
+			"description": "",
+			"item": [
+				{
+					"name": "Users/Roles index.json",
+					"request": {
+						"url": "{{url}}/users?users={{user_id}}",
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"description": ""
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "/users/{user_id}}/snippets",
 			"description": "Folder for users",
 			"item": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a new lambda, `GetIndexes`, to the GET method of the `/users` endpoint. When a request is made, the response contains an object of the following form:

```javascript
{
  "username-1": {
    "snippet-key": {
      // meta data shtuff
    },
    ...
  },
  "username-2": {
    "snippet-key": {
      // meta data shtuff
    },
    ...
  },
  ...
}
```

A query string can be used to filter the users in the response. For example, doing a GET to `/users` returns all users and their indexes. But doing a GET to `/users?users=Hopding,solkaz` will only return the indexes for `Hopding` and `solkaz`. If a user is specified in the filter list that does not exist, their entry in the response will be an empty object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #93. This new lambda allows requests for multiple user's index files to be more efficient.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.