### PR TITLE
Add validation to POST/PUT requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 ## Ignore compiled python files
 *.pyc
+tmp/
 
 ## Ignore the virtual environment
 codesplain-env/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: $(lambdas)
 #Set package variables for lambdas that need them
 Authorize: packages = axios
 AuthorizeToken: packages = axios
-GithubAccessCodeGetter: packages = axios lodash
+GitHubAccessCodeGetter: packages = axios lodash
 SaveSnippetToS3: scripts = schema
 SaveSnippetToS3: packages = cerberus
 UpdateSnippetInS3: scripts = schema

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 lambdas := Authorize AuthorizeToken DeleteSnippetFromS3 GetSnippetFromS3 SaveSnippetToS3 GenerateIndexFiles GitHubAccessCodeGetter UpdateSnippetInS3
 zipdir := zips
 lambdadir := lambdas
-.PHONY = all clean publish $(lambdas)
+.PHONY = all clean publish test $(lambdas)
 
 all: $(lambdas)
 
@@ -31,5 +31,5 @@ $(zipdir)/%.zip:
 clean:
 	rm -rf $(zipdir)
 
-
-
+test:
+	python -m unittest discover -t . -s __tests__

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 lambdas := Authorize AuthorizeToken DeleteSnippetFromS3 GetSnippetFromS3 SaveSnippetToS3 GenerateIndexFiles GitHubAccessCodeGetter UpdateSnippetInS3
 zipdir := zips
 lambdadir := lambdas
+scriptsdir := scripts
 .PHONY = all clean publish test $(lambdas)
 
 all: $(lambdas)
@@ -9,6 +10,8 @@ all: $(lambdas)
 Authorize: packages = axios
 AuthorizeToken: packages = axios
 GithubAccessCodeGetter: packages = axios lodash
+SaveSnippetToS3: scripts = schema
+UpdateSnippetInS3: scripts = schema
 
 
 #Nice alias so only the lambda name need be invoked
@@ -24,6 +27,9 @@ $(zipdir)/%.zip:
 		cp $(lambdadir)/$*/lambda_function.py tmp && \
 		pip install -t tmp $(packages); \
 	fi
+	for script in $(scripts); do \
+		cp $(scriptsdir)/$$script.py tmp; \
+	done
 	cd tmp && zip -r $* .
 	mv tmp/$*.zip $(zipdir)
 	rm -rf tmp

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ Authorize: packages = axios
 AuthorizeToken: packages = axios
 GithubAccessCodeGetter: packages = axios lodash
 SaveSnippetToS3: scripts = schema
+SaveSnippetToS3: packages = cerberus
 UpdateSnippetInS3: scripts = schema
+UpdateSnippetInS3: packages = cerberus
 
 
 #Nice alias so only the lambda name need be invoked

--- a/__tests__/test_schemas.py
+++ b/__tests__/test_schemas.py
@@ -10,20 +10,19 @@ class TestSnippetSchema(unittest.TestCase):
     def test_valid_snippet(self):
         """Should load a valid snippet dict with no errors"""
         snippet = {
-            'annotations': {},
-            'AST': {
-                'begin': 0,
-                'end': 1,
-                'tags': [],
-                'type': '',
-                'children': [],
+            "annotations": {},
+            "AST": {
+                "begin": 0,
+                "end": 1,
+                "tags": [],
+                "type": "",
+                "children": [],
             },
-            'filters': {},
-            'readOnly': True,
-            'snippet': '',
-            'snippetKey': '',
-            'snippetLanguage': '',
-            'snippetTitle': ''
+            "filters": {},
+            "readOnly": True,
+            "snippet": "",
+            "snippetLanguage": "",
+            "snippetTitle": ""
         }
         self.validator.validate(snippet)
         self.assertEqual(len(self.validator.errors), 0)
@@ -32,7 +31,6 @@ class TestSnippetSchema(unittest.TestCase):
         """Should load an invalid snippet dict with errors"""
         snippet = {
             'snippet': [],
-            'snippetKey': ['not', 'a', 'str'],
         }
         self.validator.validate(snippet)
         self.assertNotEqual(len(self.validator.errors), 0)

--- a/__tests__/test_schemas.py
+++ b/__tests__/test_schemas.py
@@ -1,0 +1,38 @@
+import unittest
+
+from cerberus import Validator
+from scripts.schema import snippet_schema
+
+class TestSnippetSchema(unittest.TestCase):
+    def setUp(self):
+        self.validator = Validator(snippet_schema)
+
+    def test_valid_snippet(self):
+        """Should load a valid snippet dict with no errors"""
+        snippet = {
+            'annotations': {},
+            'AST': {
+                'begin': 0,
+                'end': 1,
+                'tags': [],
+                'type': '',
+                'children': [],
+            },
+            'filters': {},
+            'readOnly': True,
+            'snippet': '',
+            'snippetKey': '',
+            'snippetLanguage': '',
+            'snippetTitle': ''
+        }
+        self.validator.validate(snippet)
+        self.assertEqual(len(self.validator.errors), 0)
+
+    def test_invalid_snippet(self):
+        """Should load an invalid snippet dict with errors"""
+        snippet = {
+            'snippet': [],
+            'snippetKey': ['not', 'a', 'str'],
+        }
+        self.validator.validate(snippet)
+        self.assertNotEqual(len(self.validator.errors), 0)

--- a/__tests__/test_schemas.py
+++ b/__tests__/test_schemas.py
@@ -21,8 +21,8 @@ class TestSnippetSchema(unittest.TestCase):
             "filters": {},
             "readOnly": True,
             "snippet": "",
-            "snippetLanguage": "",
-            "snippetTitle": ""
+            "snippetLanguage": "python3",
+            "snippetTitle": "title"
         }
         self.validator.validate(snippet)
         self.assertEqual(len(self.validator.errors), 0)
@@ -31,6 +31,26 @@ class TestSnippetSchema(unittest.TestCase):
         """Should load an invalid snippet dict with errors"""
         snippet = {
             'snippet': [],
+        }
+        self.validator.validate(snippet)
+        self.assertNotEqual(len(self.validator.errors), 0)
+
+    def test_invalid_snippet_invalid_language(self):
+        """Should load an invalid snippet dict with errors"""
+        snippet = {
+            "annotations": {},
+            "AST": {
+                "begin": 0,
+                "end": 1,
+                "tags": [],
+                "type": "",
+                "children": [],
+            },
+            "filters": {},
+            "readOnly": True,
+            "snippet": "",
+            "snippetLanguage": "not a real language",
+            "snippetTitle": "title"
         }
         self.validator.validate(snippet)
         self.assertNotEqual(len(self.validator.errors), 0)

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -101,7 +101,13 @@ def lambda_handler(event, context):
     body             = json.loads(event['body'])
     if not Validator(snippet_schema).validate(body):
         print 'Invalid snippet data'
-        raise ValueError
+        return {
+            'statusCode': '400',
+            'headers':    { 'Access-Control-Allow-Origin': '*' },
+            'body':       json.dumps({
+               'response': 'Invalid POST body supplied.'
+            })
+        }
     snippet_title    = body['snippetTitle']
     snippet_language = body['snippetLanguage']
     bucket           = os.environ['BucketName']

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -13,6 +13,8 @@ from schema import snippet_schema
 s3     = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
 
+snippetValidator = Validator(snippet_schema)
+
 # Returns the snippet key with the lowest possible unused postfix value.
 def generate_snippet_id(bucket, user_id, snippet_title):
     snippet_id = urllib.quote_plus(string.lower(re.sub(r'\s+', '_', snippet_title)))
@@ -99,13 +101,14 @@ def lambda_handler(event, context):
             })
         }
     body             = json.loads(event['body'])
-    if not Validator(snippet_schema).validate(body):
+    if not snippetValidator.validate(body):
         print 'Invalid snippet data'
         return {
             'statusCode': '400',
             'headers':    { 'Access-Control-Allow-Origin': '*' },
             'body':       json.dumps({
-               'response': 'Invalid POST body supplied.'
+               'response': 'Invalid POST body supplied.',
+               'errors': snippetValidator.errors
             })
         }
     snippet_title    = body['snippetTitle']

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -2,10 +2,13 @@ import json
 import urllib
 import re
 import os
+from cerberus import Validator
 from datetime import datetime
 from boto3.s3.transfer import ClientError
 import string
 import boto3 # AWS SDK for Python
+
+from schema import snippet_schema
 
 s3     = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
@@ -96,6 +99,9 @@ def lambda_handler(event, context):
             })
         }
     body             = json.loads(event['body'])
+    if not Validator(snippet_schema).validate(body):
+        print 'Invalid snippet data'
+        raise ValueError
     snippet_title    = body['snippetTitle']
     snippet_language = body['snippetLanguage']
     bucket           = os.environ['BucketName']

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -1,6 +1,7 @@
 import json
 import urllib
 import os
+from cerberus import Validator
 from datetime import datetime
 from boto3.s3.transfer import ClientError
 import boto3 # AWS SDK for Python

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -67,6 +67,9 @@ def lambda_handler(event, context):
             })
         }
     body   = json.loads(event['body'])
+    if not Validator(snippet_schema).validate(body):
+        print 'Invalid snippet data'
+        raise ValueError
     bucket = os.environ['BucketName']
     if(bucket == None):
         print 'Must specify "BucketName" env var!'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs==1.4.3
 awscli==1.11.63
 boto3==1.4.4
 botocore==1.5.39
+Cerberus==1.1
 colorama==0.3.7
 docutils==0.13.1
 funcsigs==1.0.2

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,8 +1,9 @@
 from cerberus import Validator, schema_registry
 
-requiredBoolField = { 'type': 'boolean', 'required': True }
-requiredIntField = { 'type': 'integer', 'required': True }
-requiredStringField = { 'type': 'string', 'required': True }
+ALLOWED_LANGUAGES = [
+    'python3',
+    'java'
+]
 
 annotation_schema = {
     'annotation': {
@@ -85,8 +86,23 @@ snippet_schema = {
         'schema': 'ast_schema',
         'required': True
     },
-    'readOnly': requiredBoolField,
-    'snippet': requiredStringField,
-    'snippetLanguage': requiredStringField,
-    'snippetTitle': requiredStringField,
+    'readOnly': {
+        'type': 'boolean',
+        'required': True
+    },
+    'snippet': {
+        'type': 'string',
+        'required': True
+    },
+    'snippetLanguage': {
+        'type': 'string',
+        'required': True,
+        'empty': False,
+        'allowed': ALLOWED_LANGUAGES
+    },
+    'snippetTitle': {
+        'type': 'string',
+        'required': True,
+        'empty': False
+    },
 }

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,0 +1,108 @@
+from cerberus import schema_registy
+
+filter_schema = {
+    'color': {
+        'type': 'string',
+        'required': True,
+    },
+    'count': {
+        'type': 'integer',
+        'required': True,
+    },
+    'prettyTokenName': {
+        'type': 'string',
+        'required': True,
+    },
+    'selected': {
+        'type': 'boolean',
+        'required': True,
+    }
+}
+schema_registy.add('filter', filter_schema)
+
+annotation_schema = {
+    'annotation': {
+        'type': 'string',
+        'required': True,
+    },
+    'lineNumber': {
+        'type': 'integer',
+        'required': True,
+    },
+    'lineText': {
+        'type': 'string',
+        'required': True,
+    },
+}
+
+schema_registy.add('annotation', annotation_schema)
+
+ast_schema = {
+    'begin': {
+        'type': 'integer',
+        'required': True,
+    },
+    'end': {
+        'type': 'integer',
+        'required': True,
+    },
+    'type': {
+        'type': 'string',
+        'required': True,
+    },
+    'tags': {
+        'type': 'list',
+        'schema': {
+            'type': 'string'
+        },
+        'required': True,
+    },
+    'children': {
+        'type': 'list',
+        'schema': 'ast_schema',
+        'required': True,
+    }
+}
+
+schema_registy.add('ast', ast_schema)
+
+snippet_schema = {
+    'annotations': {
+        'type': 'dict',
+        'keyschema': {
+            'type': 'integer',
+        },
+        'valueschema': 'annotation_schema',
+        'required': True,
+    },
+    'filters': {
+        'type': 'dict',
+        'keyschema': {
+            'type': 'string'
+        },
+        'valueschema': 'filter_schema',
+        'required': True,
+    },
+    'readOnly': {
+        'type': 'boolean',
+        'required': True,
+    },
+    'snippet': {
+        'type': 'string',
+        'required': True,
+    },
+    'snippetKey': {
+        'type': 'string',
+        'required': True
+    },
+    'snippetLanguage': {
+        'type': 'string',
+        'required': True
+    },
+    'snippetTitle': {
+        'type': 'string',
+        'required': True
+    },
+}
+
+schema_registy.add('snippet', snippet_schema)

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -87,7 +87,6 @@ snippet_schema = {
     },
     'readOnly': requiredBoolField,
     'snippet': requiredStringField,
-    'snippetKey': requiredStringField,
     'snippetLanguage': requiredStringField,
     'snippetTitle': requiredStringField,
 }

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,70 +1,61 @@
-from cerberus import schema_registy
+from cerberus import Validator, schema_registry
 
-filter_schema = {
-    'color': {
-        'type': 'string',
-        'required': True,
-    },
-    'count': {
-        'type': 'integer',
-        'required': True,
-    },
-    'prettyTokenName': {
-        'type': 'string',
-        'required': True,
-    },
-    'selected': {
-        'type': 'boolean',
-        'required': True,
-    }
-}
-schema_registy.add('filter', filter_schema)
+requiredBoolField = { 'type': 'bool', 'required': True }
+requiredIntField = { 'type': 'integer', 'required': True }
+requiredStringField = { 'type': 'boolean', 'required': True }
 
 annotation_schema = {
     'annotation': {
         'type': 'string',
-        'required': True,
     },
     'lineNumber': {
         'type': 'integer',
-        'required': True,
     },
     'lineText': {
         'type': 'string',
-        'required': True,
     },
 }
-
-schema_registy.add('annotation', annotation_schema)
 
 ast_schema = {
     'begin': {
         'type': 'integer',
-        'required': True,
     },
     'end': {
         'type': 'integer',
-        'required': True,
     },
     'type': {
         'type': 'string',
-        'required': True,
     },
     'tags': {
         'type': 'list',
         'schema': {
             'type': 'string'
         },
-        'required': True,
     },
     'children': {
         'type': 'list',
         'schema': 'ast_schema',
-        'required': True,
     }
 }
 
-schema_registy.add('ast', ast_schema)
+filter_schema = {
+    'color': {
+        'type': 'string',
+    },
+    'count': {
+        'type': 'integer',
+    },
+    'prettyTokenName': {
+        'type': 'string',
+    },
+    'selected': {
+        'type': 'boolean',
+    }
+}
+
+schema_registry.add('annotation_schema', annotation_schema)
+schema_registry.add('ast_schema', ast_schema)
+schema_registry.add('filter_schema', filter_schema)
 
 snippet_schema = {
     'annotations': {
@@ -72,37 +63,31 @@ snippet_schema = {
         'keyschema': {
             'type': 'integer',
         },
-        'valueschema': 'annotation_schema',
-        'required': True,
+        'valueschema': {
+            'type': 'dict',
+            'schema': 'annotation_schema',
+        },
+        'required': True
     },
     'filters': {
         'type': 'dict',
         'keyschema': {
             'type': 'string'
         },
-        'valueschema': 'filter_schema',
-        'required': True,
-    },
-    'readOnly': {
-        'type': 'boolean',
-        'required': True,
-    },
-    'snippet': {
-        'type': 'string',
-        'required': True,
-    },
-    'snippetKey': {
-        'type': 'string',
+        'valueschema': {
+            'type': 'dict',
+            'schema': 'filter_schema'
+        },
         'required': True
     },
-    'snippetLanguage': {
-        'type': 'string',
+    'AST': {
+        'type': 'dict',
+        'schema': 'ast_schema',
         'required': True
     },
-    'snippetTitle': {
-        'type': 'string',
-        'required': True
-    },
+    'readOnly': requiredBoolField,
+    'snippet': requiredStringField,
+    'snippetKey': requiredStringField,
+    'snippetLanguage': requiredStringField,
+    'snippetTitle': requiredStringField,
 }
-
-schema_registy.add('snippet', snippet_schema)

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,8 +1,8 @@
 from cerberus import Validator, schema_registry
 
-requiredBoolField = { 'type': 'bool', 'required': True }
+requiredBoolField = { 'type': 'boolean', 'required': True }
 requiredIntField = { 'type': 'integer', 'required': True }
-requiredStringField = { 'type': 'boolean', 'required': True }
+requiredStringField = { 'type': 'string', 'required': True }
 
 annotation_schema = {
     'annotation': {


### PR DESCRIPTION
## Description
This PR adds validation to the SaveSnippetToS3 and UpdateSnippetinS3 lambda functions. It uses [Cerberus](http://docs.python-cerberus.org/en/stable/) to do so, validating that the body has the correct shape, the `snippetTitle` field is nonempty, and `snippetLanguage` is a valid language (`python3` or `java`)

## Motivation and Context
Fixes #86 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
