### PR TITLE
don't fail on non-merge build

### DIFF
--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -8,6 +8,7 @@ sleep 1
 echo "Feature: $featureBranch"
 
 if [ "$featureBranch" == "-1" ]; then
-  exit 1
+  echo "No feature branch to delete"
+  exit 0
 fi
 aws cloudformation --region us-west-2 delete-stack --stack-name "CodesplainFeature-$featureBranch"


### PR DESCRIPTION
## Description
This allows for non-PR changes to master to not break. So README changes don't cause a break.

## Motivation and Context
Somewhat fixes #49, but I'm not sure there is a complete fix without removing the deploys from the circle yaml.  But the need to re-build master without a PR or new commit is not a common problem
