### PR TITLE
Ignore whitelist

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ deployment:
 
       # Deploy a new stack for this version
       - >
+        IgnoreWhitelist="true" &&
         EnvVersion=$CIRCLE_TAG && EnvVersion=${EnvVersion//./_} &&
         CloudFormationVersion=$CIRCLE_TAG && CloudFormationVersion=${CloudFormationVersion//./-} &&
         aws cloudformation deploy
@@ -101,6 +102,7 @@ deployment:
 
       # Deploy or update feature stack based on new lambda code and template
       - >
+        IgnoreWhitelist="true" &&
         EnvVersion=$CIRCLE_BRANCH && EnvVersion=${EnvVersion//-/} &&
         aws cloudformation deploy
         --stack-name "CodesplainFeature-$CIRCLE_BRANCH"

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,6 @@ deployment:
 
       # Deploy a new stack for this version
       - >
-        IgnoreWhitelist="true" &&
         EnvVersion=$CIRCLE_TAG && EnvVersion=${EnvVersion//./_} &&
         CloudFormationVersion=$CIRCLE_TAG && CloudFormationVersion=${CloudFormationVersion//./-} &&
         aws cloudformation deploy
@@ -43,6 +42,7 @@ deployment:
         Title="CodesplainAPI: $CIRCLE_TAG"
         CircleBuild="$CIRCLE_BUILD_NUM"
         ParserPath="$RELEASED_PARSER"
+        IgnoreWhitelist="true"
         --region us-west-2
 
   master:
@@ -102,7 +102,6 @@ deployment:
 
       # Deploy or update feature stack based on new lambda code and template
       - >
-        IgnoreWhitelist="true" &&
         EnvVersion=$CIRCLE_BRANCH && EnvVersion=${EnvVersion//-/} &&
         aws cloudformation deploy
         --stack-name "CodesplainFeature-$CIRCLE_BRANCH"
@@ -114,4 +113,5 @@ deployment:
         ClientID="$AuthId"
         Title="Codesplain Feature:$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"
         CircleBuild="$CIRCLE_BUILD_NUM"
+        IgnoreWhitelist="true"
         --region us-west-2

--- a/circle.yml
+++ b/circle.yml
@@ -113,5 +113,4 @@ deployment:
         ClientID="$AuthId"
         Title="Codesplain Feature:$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"
         CircleBuild="$CIRCLE_BUILD_NUM"
-        IgnoreWhitelist="true"
         --region us-west-2

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -64,7 +64,7 @@ Resources:
       Role: !Ref Role
       Environment:
         Variables:
-          IGNORE_WHITELIST: false
+          IGNORE_WHITELIST: !Ref IgnoreWhitelist
           CLIENT_ID: !Ref ClientID
           CLIENT_SECRET: !Ref ClientSecret
           ORG_WHITELIST: "maryvilledev"
@@ -731,3 +731,7 @@ Parameters:
     Description: Build number that deployed API
     Type: String
     Default: "CircleBuildUnknown"
+  IgnoreWhitelist:
+    Description: Flag for limiting Github auth to whitelisted ORGs
+    Type: String
+    Default: "false"


### PR DESCRIPTION
## Description
This fixes a regression that was caused when we moved to CircleCI prod deployments.  I tested on a feature branch and then removed that logic.  So Prod is whitelist ignored, dev/feature branches are protected.  Already fixed this in live prod, `v0.5`.

## Motivation and Context
Fixes https://github.com/maryvilledev/codesplain/issues/86
