### PR TITLE
Add request/response JSONSchema validation

### DIFF
--- a/api_tests/users/user_id/snippets/snippet_id/test_endpoint.py
+++ b/api_tests/users/user_id/snippets/snippet_id/test_endpoint.py
@@ -1,7 +1,6 @@
 import unittest
 import json
 import requests
-from jsonschema import validate, ValidationError
 import config
 import testfor
 
@@ -14,7 +13,7 @@ class TestEndpoint(unittest.TestCase):
         cls.SNIPPET_ID   = config_dict['snippet_id']
         cls.API_URL      = config_dict['url'] + '/users/' + cls.USER_ID + '/snippets/' + cls.SNIPPET_ID
         cls.INVALID_SNIPPET_KEY = config_dict['invalid_snippet_key']
-        cls.INVALID_SNIPPET_URL = '%s/users/%s/snippets/%s' % (config_dict['url'], cls.USER_ID, cls.INVALID_SNIPPET_KEY) 
+        cls.INVALID_SNIPPET_URL = '%s/users/%s/snippets/%s' % (config_dict['url'], cls.USER_ID, cls.INVALID_SNIPPET_KEY)
         cls.ACCESS_TOKEN = config_dict['access_token']
         cls.SNIPPET      = json.dumps(config_dict['snippet'])
 
@@ -60,7 +59,7 @@ class TestEndpoint(unittest.TestCase):
         testfor.status_code(self, r, 404)
         testfor.cors_headers(self, r, {'Origin': '*'})
         testfor.body(self, r, 'No snippet exists with key "%s/%s"' % (TestEndpoint.USER_ID, TestEndpoint.INVALID_SNIPPET_KEY))
-    
+
 
     def test_put (self, note):
         print '\tTesting PUT method (' + note + ')'
@@ -103,3 +102,39 @@ class TestEndpoint(unittest.TestCase):
         testfor.status_code(self, r, 401)
         testfor.valid_json(self, r)
         testfor.key_val(self, r, 'message', 'Unauthorized')
+
+    def test_put_no_title (self):
+        print '\tTesting PUT method (with no snippet title)'
+        headers = { 'Authorization' : self.ACCESS_TOKEN }
+        data = {
+            "snippetLanguage": "python3",
+            "AST": {},
+            "snippetTitle": "",
+            "snippet": "",
+            "readOnly": False,
+            "filters": {},
+            "annotations": {}
+          }
+        r = requests.put(self.API_URL, headers=headers, data=self.SNIPPET_NO_TITLE)
+
+        testfor.status_code(self, r, 400)
+        testfor.valid_json(self, r)
+        testfor.key_val(self, r, 'message', 'Invalid request body')
+
+    def test_put_invalid_language (self):
+        print '\tTesting PUT method (with invalid snippet language)'
+        headers = { 'Authorization' : self.ACCESS_TOKEN }
+        data = {
+            "snippetLanguage": "python2",
+            "AST": {},
+            "snippetTitle": "title",
+            "snippet": "",
+            "readOnly": False,
+            "filters": {},
+            "annotations": {}
+        }
+        r = requests.put(self.API_URL, headers=headers, data=self.SNIPPET_INVALID_LANG)
+
+        testfor.status_code(self, r, 400)
+        testfor.valid_json(self, r)
+        testfor.key_val(self, r, 'message', 'Invalid request body')

--- a/api_tests/users/user_id/snippets/test_endpoint.py
+++ b/api_tests/users/user_id/snippets/test_endpoint.py
@@ -100,3 +100,39 @@ class TestEndpoint(unittest.TestCase):
         testfor.cors_headers(self, r, { 'Origin' : '*' })
         testfor.valid_json(self, r)
         testfor.key_val(self, r, 'response', 'POST requests must not have empty bodies.')
+
+    def test_post_no_title (self):
+        print '\tTesting POSTT method (with no snippet title)'
+        headers = { 'Authorization' : self.ACCESS_TOKEN }
+        data = {
+            "snippetLanguage": "python3",
+            "AST": {},
+            "snippetTitle": "",
+            "snippet": "",
+            "readOnly": False,
+            "filters": {},
+            "annotations": {}
+          }
+        r = requests.post(self.API_URL, headers=headers, data=self.SNIPPET_NO_TITLE)
+
+        testfor.status_code(self, r, 400)
+        testfor.valid_json(self, r)
+        testfor.key_val(self, r, 'message', 'Invalid request body')
+
+    def test_post_invalid_language (self):
+        print '\tTesting POSTT method (with invalid snippet language)'
+        headers = { 'Authorization' : self.ACCESS_TOKEN }
+        data = {
+            "snippetLanguage": "python2",
+            "AST": {},
+            "snippetTitle": "title",
+            "snippet": "",
+            "readOnly": False,
+            "filters": {},
+            "annotations": {}
+        }
+        r = requests.post(self.API_URL, headers=headers, data=self.SNIPPET_INVALID_LANG)
+
+        testfor.status_code(self, r, 400)
+        testfor.valid_json(self, r)
+        testfor.key_val(self, r, 'message', 'Invalid request body')

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -724,7 +724,10 @@ Resources:
                   - "prettyTokenName"
                   - "selected"
             title: "Snippet"
-
+        x-amazon-apigateway-request-validators:
+          Validate body:
+            validateRequestParameters: false
+            validateRequestBody: true
   GenerateIndexFiles:
     Type: 'AWS::Serverless::Function'
     Properties:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -685,7 +685,7 @@ Resources:
               children:
                 type: "array"
                 items:
-                  $ref: "#/definitions/SnippetSaveDataAST"
+                  $ref: "#/CodesplainAPI/definitions/SnippetSaveDataAST"
               detail:
                 type: "array"
                 items:
@@ -756,7 +756,7 @@ Resources:
                   - "prettyTokenName"
                   - "selected"
               AST:
-                $ref: "#/definitions/SnippetSaveDataAST"
+                $ref: "#/CodesplainAPI/definitions/SnippetSaveDataAST"
             title: "Snippet"
 
   GenerateIndexFiles:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -461,7 +461,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/definitions/SnippetSaveData"
+                  $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
               responses:
                 "200":
                   description: "200 response"
@@ -531,7 +531,7 @@ Resources:
                 "200":
                   description: "200 response"
                   schema:
-                    $ref: "#/definitions/SnippetSaveData"
+                    $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
                 "404":
                   description: "404 response"
               x-amazon-apigateway-integration:
@@ -562,7 +562,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/definitions/SnippetSaveData"
+                  $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
               responses:
                 "400":
                   description: "400 response"

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -452,6 +452,8 @@ Resources:
             post:
               consumes:
               - "application/json"
+              produces:
+              - "application/json"
               parameters:
               - name: "user_id"
                 in: "path"
@@ -548,6 +550,8 @@ Resources:
                 type: "aws_proxy"
             put:
               consumes:
+              - "application/json"
+              produces:
               - "application/json"
               parameters:
               - name: "snippet_id"

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -660,41 +660,9 @@ Resources:
             name: "x-api-key"
             in: "header"
         definitions:
-          SnippetSaveDataAST:
-            type: "object"
-            required:
-            - "ast_type"
-            - "begin"
-            - "children"
-            - "end"
-            - "tags"
-            properties:
-              ast_type:
-                type: "string"
-                title: "Token type"
-              begin:
-                type: "number"
-                title: "Beginning position"
-              end:
-                type: "number"
-                title: "End position"
-              tags:
-                type: "array"
-                items:
-                  type: "string"
-              detail:
-                type: "array"
-                items:
-                  type: "object"
-                  properties:
-                    handler:
-                      type: "string"
-                      title: "Handler function name"
-            title: "Abstract Syntax Tree"
           SnippetSaveData:
             type: "object"
             required:
-            - "AST"
             - "annotations"
             - "filters"
             - "readOnly"
@@ -751,8 +719,6 @@ Resources:
                   - "count"
                   - "prettyTokenName"
                   - "selected"
-              AST:
-                $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveDataAST"
             title: "Snippet"
 
   GenerateIndexFiles:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -461,7 +461,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
+                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
               responses:
                 "200":
                   description: "200 response"
@@ -531,7 +531,7 @@ Resources:
                 "200":
                   description: "200 response"
                   schema:
-                    $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
+                    $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
                 "404":
                   description: "404 response"
               x-amazon-apigateway-integration:
@@ -562,7 +562,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/CodesplainAPI/definitions/SnippetSaveData"
+                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
               responses:
                 "400":
                   description: "400 response"
@@ -685,7 +685,7 @@ Resources:
               children:
                 type: "array"
                 items:
-                  $ref: "#/CodesplainAPI/definitions/SnippetSaveDataAST"
+                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveDataAST"
               detail:
                 type: "array"
                 items:
@@ -756,7 +756,7 @@ Resources:
                   - "prettyTokenName"
                   - "selected"
               AST:
-                $ref: "#/CodesplainAPI/definitions/SnippetSaveDataAST"
+                $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveDataAST"
             title: "Snippet"
 
   GenerateIndexFiles:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -452,18 +452,16 @@ Resources:
             post:
               consumes:
               - "application/json"
-              produces:
-              - "application/json"
               parameters:
               - name: "user_id"
                 in: "path"
                 required: true
                 type: "string"
               - in: "body"
-                name: "Snippet"
+                name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/definitions/Snippet"
+                  $ref: "#/definitions/SnippetSaveData"
               responses:
                 "200":
                   description: "200 response"
@@ -474,6 +472,7 @@ Resources:
                   description: "500 response"
               security:
               - GithubAuthorizer: []
+              x-amazon-apigateway-request-validator: "Validate body"
               x-amazon-apigateway-integration:
                 credentials: !Ref Role
                 responses:
@@ -532,7 +531,7 @@ Resources:
                 "200":
                   description: "200 response"
                   schema:
-                    $ref: "#/definitions/Snippet"
+                    $ref: "#/definitions/SnippetSaveData"
                 "404":
                   description: "404 response"
               x-amazon-apigateway-integration:
@@ -550,8 +549,6 @@ Resources:
             put:
               consumes:
               - "application/json"
-              produces:
-              - "application/json"
               parameters:
               - name: "snippet_id"
                 in: "path"
@@ -562,10 +559,10 @@ Resources:
                 required: true
                 type: "string"
               - in: "body"
-                name: "Snippet"
+                name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/definitions/Snippet"
+                  $ref: "#/definitions/SnippetSaveData"
               responses:
                 "400":
                   description: "400 response"
@@ -573,6 +570,7 @@ Resources:
                   description: "204 response"
               security:
               - GithubAuthorizer: []
+              x-amazon-apigateway-request-validator: "Validate body"
               x-amazon-apigateway-integration:
                 credentials: !Ref Role
                 responses:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -682,10 +682,6 @@ Resources:
                 type: "array"
                 items:
                   type: "string"
-              children:
-                type: "array"
-                items:
-                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveDataAST"
               detail:
                 type: "array"
                 items:

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -459,8 +459,8 @@ Resources:
                 in: "path"
                 required: true
                 type: "string"
-              - in: "body"
-                name: "SnippetSaveData"
+              - name: "SnippetSaveData"
+                in: "body"
                 required: true
                 schema:
                   $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
@@ -562,8 +562,8 @@ Resources:
                 in: "path"
                 required: true
                 type: "string"
-              - in: "body"
-                name: "SnippetSaveData"
+              - name: "SnippetSaveData"
+                in: "body"
                 required: true
                 schema:
                   $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -463,7 +463,7 @@ Resources:
                 in: "body"
                 required: true
                 schema:
-                  $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                  $ref: "#/definitions/SnippetSaveData"
               responses:
                 "200":
                   description: "200 response"
@@ -533,7 +533,7 @@ Resources:
                 "200":
                   description: "200 response"
                   schema:
-                    $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                    $ref: "#/definitions/SnippetSaveData"
                 "404":
                   description: "404 response"
               x-amazon-apigateway-integration:
@@ -566,7 +566,7 @@ Resources:
                 in: "body"
                 required: true
                 schema:
-                  $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                  $ref: "#/definitions/SnippetSaveData"
               responses:
                 "400":
                   description: "400 response"

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -660,17 +660,104 @@ Resources:
             name: "x-api-key"
             in: "header"
         definitions:
-          Snippet:
+          SnippetSaveDataAST:
             type: "object"
             required:
+            - "ast_type"
+            - "begin"
+            - "children"
+            - "end"
+            - "tags"
+            properties:
+              ast_type:
+                type: "string"
+                title: "Token type"
+              begin:
+                type: "number"
+                title: "Beginning position"
+              end:
+                type: "number"
+                title: "End position"
+              tags:
+                type: "array"
+                items:
+                  type: "string"
+              children:
+                type: "array"
+                items:
+                  $ref: "#/definitions/SnippetSaveDataAST"
+              detail:
+                type: "array"
+                items:
+                  type: "object"
+                  properties:
+                    handler:
+                      type: "string"
+                      title: "Handler function name"
+            title: "Abstract Syntax Tree"
+          SnippetSaveData:
+            type: "object"
+            required:
+            - "AST"
+            - "annotations"
+            - "filters"
+            - "readOnly"
             - "snippet"
+            - "snippetLanguage"
             - "snippetTitle"
             properties:
-              snippet:
-                type: "string"
               snippetTitle:
                 type: "string"
-
+                description: "Title of the snippet"
+                title: "Snippet Title"
+                minLength: 1
+                default: "Snippet title"
+              snippet:
+                type: "string"
+                description: "Contents of the snippet"
+                title: "Snippet Contents"
+                default: "Snippet contents"
+              snippetLanguage:
+                type: "string"
+                title: "Snippet Language"
+                enum:
+                - "python3"
+                - "java"
+                default: "python3"
+              readOnly:
+                type: "boolean"
+                title: "Is read-only"
+                default: false
+              annotations:
+                type: "object"
+                title: "Annotations"
+                properties: {}
+              filters:
+                type: "object"
+                title: "Filters"
+                additionalProperties:
+                  type: "object"
+                  properties:
+                    color:
+                      type: "string"
+                      title: "Color"
+                    count:
+                      type: "number"
+                      title: "Number of Occurrences"
+                    prettyTokenName:
+                      type: "string"
+                      title: "Token display name"
+                    selected:
+                      type: "boolean"
+                      title: "Filter is selected"
+                  required:
+                  - "color"
+                  - "count"
+                  - "prettyTokenName"
+                  - "selected"
+              AST:
+                $ref: "#/definitions/SnippetSaveDataAST"
+            title: "Snippet"
 
   GenerateIndexFiles:
     Type: 'AWS::Serverless::Function'

--- a/codesplainTemplate.yaml
+++ b/codesplainTemplate.yaml
@@ -461,7 +461,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                  $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
               responses:
                 "200":
                   description: "200 response"
@@ -531,7 +531,7 @@ Resources:
                 "200":
                   description: "200 response"
                   schema:
-                    $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                    $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
                 "404":
                   description: "404 response"
               x-amazon-apigateway-integration:
@@ -562,7 +562,7 @@ Resources:
                 name: "SnippetSaveData"
                 required: true
                 schema:
-                  $ref: "#/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
+                  $ref: "#/Resources/CodesplainAPI/Properties/DefinitionBody/definitions/SnippetSaveData"
               responses:
                 "400":
                   description: "400 response"

--- a/jsonschema.json
+++ b/jsonschema.json
@@ -1,0 +1,158 @@
+{
+  "title": "Snippet",
+  "type": "object",
+  "required": [
+    "snippetTitle",
+    "snippet",
+    "readOnly",
+    "snippetLanguage",
+    "annotations",
+    "filters",
+    "AST"
+  ],
+  "definitions": {
+    "AST": {
+      "type": "object",
+      "title": "Abstract Syntax Tree",
+      "required": [
+        "ast_type",
+        "begin",
+        "end",
+        "tags",
+        "children"
+      ],
+      "properties": {
+        "ast_type": {
+          "type": "string",
+          "title": "Token type"
+        },
+        "begin": {
+          "type": "number",
+          "title": "Beginning position"
+        },
+        "end": {
+          "type": "number",
+          "title": "End position"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AST"
+          }
+        },
+        "detail": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "handler": {
+                "type": "string",
+                "title": "Handler function name"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "snippetTitle": {
+      "type": "string",
+      "title": "Snippet Title",
+      "description": "Title of the snippet",
+      "minLength": 1,
+      "default": "Snippet title"
+    },
+    "snippet": {
+      "type": "string",
+      "title": "Snippet Contents",
+      "description": "Contents of the snippet",
+      "default": "Snippet contents"
+    },
+    "snippetLanguage": {
+      "type": "string",
+      "title": "Snippet Language",
+      "enum": [
+        "python3",
+        "java"
+      ],
+      "default": "python3"
+    },
+    "readOnly": {
+      "type": "boolean",
+      "title": "Is read-only",
+      "default": false
+    },
+    "annotations": {
+      "type": "object",
+      "title": "Annotations",
+      "properties": {},
+      "additionalProperties": false,
+      "patternProperties": {
+        "\\b[0-9]+\\b": {
+          "type": "object",
+          "required": [
+            "annotation",
+            "lineNumber",
+            "lineText"
+          ],
+          "properties": {
+            "annotation": {
+              "type": "string",
+              "title": "Annotation"
+            },
+            "lineNumber": {
+              "type": "number",
+              "title": "Line Annotated"
+            },
+            "lineText": {
+              "type": "string",
+              "title": "Text Content of Line Annotated"
+            }
+          }
+        }
+      }
+    },
+    "filters": {
+      "type": "object",
+      "title": "Filters",
+      "properties": {},
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "color",
+          "count",
+          "prettyTokenName",
+          "selected"
+        ],
+        "properties": {
+          "color": {
+            "type": "string",
+            "title": "Color"
+          },
+          "count": {
+            "type": "number",
+            "title": "Number of Occurrences"
+          },
+          "prettyTokenName": {
+            "type": "string",
+            "title": "Token display name"
+          },
+          "selected": {
+            "type": "boolean",
+            "title": "Filter is selected"
+          }
+        }
+      }
+    },
+    "AST": {
+      "$ref": "#/definitions/AST"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add json-schemas to validate request/response bodies against.

## Motivation and Context
Fixes #86 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.