### PR TITLE
Refactor lambdas to respond with 401 error if token validation fails

### DIFF
--- a/lambdas/AuthorizeToken/lambda_function.py
+++ b/lambdas/AuthorizeToken/lambda_function.py
@@ -34,4 +34,4 @@ def lambda_handler(event, context):
     if is_valid(role, user, orgs):
         return generate_resp(200, 'authorized')
 
-    return generate_resp(400, 'not authorized to acces this resource')
+    return generate_resp(400, 'not authorized to access this resource')

--- a/lambdas/DeleteSnippetFromS3/lambda_function.py
+++ b/lambdas/DeleteSnippetFromS3/lambda_function.py
@@ -50,7 +50,12 @@ def lambda_handler(event, context):
     lambda_payload_resp = json.loads(lambda_auth['Payload'].read())
 
     if(lambda_payload_resp['statusCode'] == '400'):
-        return {'statusCode': '400', 'body': json.dumps({'response': lambda_payload_resp['body']})}
+        return {
+            'statusCode': '401',
+            'body': json.dumps({
+                'response': lambda_payload_resp['body']
+            })
+        }
 
     # -------- Otherwise, delete from S3 -------- #
     snippet_key = event['pathParameters']['snippet_id']
@@ -58,14 +63,20 @@ def lambda_handler(event, context):
     bucket = os.environ['BucketName']
 
     if (not object_exists(bucket, key)):
-        return {'statusCode': '400', 'body':json.dumps({'response': snippet_key + ' does not exist'})}
+        return {
+            'statusCode': '404',
+            'body': json.dumps({
+                'response': snippet_key + ' does not exist'
+            })
+        }
     else:
         delete_obj_from_s3(bucket, key)
 
     update_index_file(
         snippet_key,
         bucket,
-        user_id)
+        user_id
+    )
     return {
         'statusCode': '200',
         'headers': {'Access-Control-Allow-Origin': '*'},

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -76,25 +76,17 @@ def lambda_handler(event, context):
             'userID': user_id
         }))
 
-    # Respond with 400 is user is not authorized
+    # Respond with 401 is user is not authorized
     resp_payload = json.loads(lambda_auth['Payload'].read())
     if(resp_payload['statusCode'] == '400'):
         return {
-            'statusCode': '400',
+            'statusCode': '401',
             'body': json.dumps({
                 'response': lambda_payload_resp['body']
             })
         }
 
     # -------- Otherwise, user is authorized, so save to S3 -------- #
-    if(event['body'] == None):
-        return {
-            'statusCode': '400',
-            'headers':    { 'Access-Control-Allow-Origin': '*' },
-            'body':       json.dumps({
-               'response': 'POST requests must not have empty bodies.'
-            })
-        }
     body             = json.loads(event['body'])
     snippet_title    = body['snippetTitle']
     snippet_language = body['snippetLanguage']

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -47,25 +47,17 @@ def lambda_handler(event, context):
             'userID': user_id
         }))
 
-    # Respond with 400 if user is not authorized
+    # Respond with 401 if user is not authorized
     resp_payload = json.loads(resp['Payload'].read())
     if(resp_payload['statusCode'] == '400'):
         return {
-            'statusCode': '400',
+            'statusCode': '401',
             'body': json.dumps({
                 'response': resp_payload['body']
             })
         }
 
     # ----- Otherwise, user is authorized, so save to S3 ----- #
-    if(event['body'] == None):
-        return {
-            'statusCode': '400',
-            'headers':    { 'Access-Control-Allow-Origin': '*' },
-            'body':       json.dumps({
-               'response': 'PUT requests must not have empty bodies.'
-            })
-        }
     body   = json.loads(event['body'])
     bucket = os.environ['BucketName']
     if(bucket == None):


### PR DESCRIPTION
## Description
If a user attempts to make a request (to save, update, or delete a snippet), the lambda will respond with a 401 error instead of a generic 400.

## Motivation and Context
Needed to fix [this issue](https://github.com/maryvilledev/codesplainUI/issues/465)

## Checklist:
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.