### PR TITLE
Fix timestamps

### DIFF
--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -58,15 +58,15 @@ def update_index_file(bucket, user_id, snippet_key, entry):
 
 # Saves the given body to the given bucket under the given key
 def save_to_s3(bucket, user_id, snippet_key, body):
-    s3Bucket = s3.Bucket(bucket)
+    s3_bucket = s3_resource.Bucket(bucket)
     key = user_id + '/' + snippet_key
     try:
-        s3Obj = s3Bucket.put_object(Body=body, Bucket=bucket, Key=key)
+        s3_obj = s3_bucket.put_object(Body=body, Bucket=bucket, Key=key)
     except ClientError as error:
         print 'Error putting object %s into bucket %s. Make sure your bucket ' \
         'exists and is in the same region as this function.' % (key, bucket)
         raise error
-    return s3Obj
+    return s3_obj
 
 # Lambda handler function
 def lambda_handler(event, context):

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -58,9 +58,10 @@ def update_index_file(bucket, user_id, snippet_key, entry):
 
 # Saves the given body to the given bucket under the given key
 def save_to_s3(bucket, user_id, snippet_key, body):
+    s3Bucket = s3.Bucket(bucket)
     key = user_id + '/' + snippet_key
     try:
-        s3Obj = s3.put_object(Body=body, Bucket=bucket, Key=key)
+        s3Obj = s3Bucket.put_object(Body=body, Bucket=bucket, Key=key)
     except ClientError as error:
         print 'Error putting object %s into bucket %s. Make sure your bucket ' \
         'exists and is in the same region as this function.' % (key, bucket)

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -15,7 +15,7 @@ s3_resource = boto3.resource('s3')
 def get_last_modified(bucket, user_id, snippet_key):
     key = user_id + '/' + snippet_key
     obj = s3_resource.Object(bucket, key)
-    return obj.last_modified
+    return obj.last_modified.isoformat()
 
 # Returns the snippet key with the lowest possible unused postfix value.
 def generate_snippet_id(bucket, user_id, snippet_title):

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -10,6 +10,12 @@ import boto3 # AWS SDK for Python
 s3     = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
 
+# Returns time the snippet was last modified
+def get_last_modified(bucket, user_id, snippet_key):
+    key = user_id + '/' + snippet_key
+    obj = s3.Object(bucket, key)
+    return obj.last_modified
+
 # Returns the snippet key with the lowest possible unused postfix value.
 def generate_snippet_id(bucket, user_id, snippet_title):
     snippet_id = urllib.quote_plus(string.lower(re.sub(r'\s+', '_', snippet_title)))
@@ -100,7 +106,7 @@ def lambda_handler(event, context):
     new_entry = {
         'snippetTitle': snippet_title,
         'language':     snippet_language,
-        'lastEdited':   datetime.utcnow().isoformat()
+        'lastEdited':   get_last_modified(bucket, user_id, snippet_id),
     }
     update_index_file(bucket, user_id, snippet_id, new_entry)
     return {

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -12,8 +12,8 @@ client = boto3.client('lambda')
 s3_resource = boto3.resource('s3')
 
 # Returns time the s3 Object was last modified
-def get_last_modified(s3Object):
-    return s3Object.last_modified.isoformat()
+def get_last_modified(s3_object):
+    return s3_object.last_modified.isoformat()
 
 # Returns the snippet key with the lowest possible unused postfix value.
 def generate_snippet_id(bucket, user_id, snippet_title):
@@ -103,11 +103,11 @@ def lambda_handler(event, context):
         raise error
     snippet_id = generate_snippet_id(bucket, user_id, snippet_title)
 
-    s3Obj = save_to_s3(bucket, user_id, snippet_id, event['body'])
+    s3_object = save_to_s3(bucket, user_id, snippet_id, event['body'])
     new_entry = {
         'snippetTitle': snippet_title,
         'language':     snippet_language,
-        'lastEdited':   get_last_modified(s3Obj),
+        'lastEdited':   get_last_modified(s3_object),
     }
     update_index_file(bucket, user_id, snippet_id, new_entry)
     return {

--- a/lambdas/SaveSnippetToS3/lambda_function.py
+++ b/lambdas/SaveSnippetToS3/lambda_function.py
@@ -7,13 +7,14 @@ from boto3.s3.transfer import ClientError
 import string
 import boto3 # AWS SDK for Python
 
-s3     = boto3.client('s3', 'us-west-2')
+s3 = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
+s3_resource = boto3.resource('s3')
 
 # Returns time the snippet was last modified
 def get_last_modified(bucket, user_id, snippet_key):
     key = user_id + '/' + snippet_key
-    obj = s3.Object(bucket, key)
+    obj = s3_resource.Object(bucket, key)
     return obj.last_modified
 
 # Returns the snippet key with the lowest possible unused postfix value.

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -5,8 +5,15 @@ from datetime import datetime
 from boto3.s3.transfer import ClientError
 import boto3 # AWS SDK for Python
 
-s3     = boto3.client('s3', 'us-west-2')
+s3 = boto3.client('s3', 'us-west-2')
 client = boto3.client('lambda')
+s3_resource = boto3.resource('s3')
+
+# Returns time the snippet was last modified
+def get_last_modified(bucket, user_id, snippet_key):
+    key = user_id + '/' + snippet_key
+    obj = s3_resource.Object(bucket, key)
+    return obj.last_modified.isoformat()
 
 # Updates index file and writes to S3. Creates new one if needed.
 def update_index_file(bucket, user_id, snippet_key, entry):

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -27,9 +27,10 @@ def update_index_file(bucket, user_id, snippet_key, entry):
 
 # Saves the given body to the given bucket under the given key
 def save_to_s3(bucket, user_id, snippet_key, body):
+    s3Bucket = s3.Bucket(bucket)
     key = user_id + '/' + snippet_key
     try:
-        s3Obj = s3.put_object(Bucket=bucket, Key=key, Body=body)
+        s3Obj = s3Bucket.put_object(Bucket=bucket, Key=key, Body=body)
     except ClientError as error:
         print 'Error putting object %s into bucket %s. Make sure your bucket ' \
         'exists and is in the same region as this function.' % (key, bucket)

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -10,10 +10,8 @@ client = boto3.client('lambda')
 s3_resource = boto3.resource('s3')
 
 # Returns time the snippet was last modified
-def get_last_modified(bucket, user_id, snippet_key):
-    key = user_id + '/' + snippet_key
-    obj = s3_resource.Object(bucket, key)
-    return obj.last_modified.isoformat()
+def get_last_modified(s3Object):
+    return s3Object.last_modified.isoformat()
 
 # Updates index file and writes to S3. Creates new one if needed.
 def update_index_file(bucket, user_id, snippet_key, entry):
@@ -31,11 +29,12 @@ def update_index_file(bucket, user_id, snippet_key, entry):
 def save_to_s3(bucket, user_id, snippet_key, body):
     key = user_id + '/' + snippet_key
     try:
-        s3.put_object(Bucket=bucket, Key=key, Body=body)
+        s3Obj = s3.put_object(Bucket=bucket, Key=key, Body=body)
     except ClientError as error:
         print 'Error putting object %s into bucket %s. Make sure your bucket ' \
         'exists and is in the same region as this function.' % (key, bucket)
         raise error
+    return s3Obj
 
 # Lambda handler function
 def lambda_handler(event, context):
@@ -71,11 +70,11 @@ def lambda_handler(event, context):
         print 'Must specify "BucketName" env var!'
         raise error
 
-    save_to_s3(bucket, user_id, snippet_id, event['body'])
+    s3Obj = save_to_s3(bucket, user_id, snippet_id, event['body'])
     new_entry = {
         'snippetTitle': body['snippetTitle'],
         'language':     body['snippetLanguage'],
-        'lastEdited':   get_last_modified(bucket, user_id, snippet_id)
+        'lastEdited':   get_last_modified(s3Obj)
     }
     update_index_file(bucket, user_id, snippet_id, new_entry)
     return {

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -75,7 +75,7 @@ def lambda_handler(event, context):
     new_entry = {
         'snippetTitle': body['snippetTitle'],
         'language':     body['snippetLanguage'],
-        'lastEdited':   datetime.utcnow().isoformat()
+        'lastEdited':   get_last_modified(bucket, user_id, snippet_id)
     }
     update_index_file(bucket, user_id, snippet_id, new_entry)
     return {

--- a/lambdas/UpdateSnippetInS3/lambda_function.py
+++ b/lambdas/UpdateSnippetInS3/lambda_function.py
@@ -27,15 +27,15 @@ def update_index_file(bucket, user_id, snippet_key, entry):
 
 # Saves the given body to the given bucket under the given key
 def save_to_s3(bucket, user_id, snippet_key, body):
-    s3Bucket = s3.Bucket(bucket)
+    s3_bucket = s3_resource.Bucket(bucket)
     key = user_id + '/' + snippet_key
     try:
-        s3Obj = s3Bucket.put_object(Bucket=bucket, Key=key, Body=body)
+        s3_obj = s3_bucket.put_object(Bucket=bucket, Key=key, Body=body)
     except ClientError as error:
         print 'Error putting object %s into bucket %s. Make sure your bucket ' \
         'exists and is in the same region as this function.' % (key, bucket)
         raise error
-    return s3Obj
+    return s3_obj
 
 # Lambda handler function
 def lambda_handler(event, context):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Timestamps are now obtained by scraping the metadata off the S3 object, rather than the `datetime` python API. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Timestamps were not correct.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
